### PR TITLE
Insop/fix skab data

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,7 +131,7 @@ python3 metrics_expts.py
 ## Credits
 This repository is forked from https://github.com/KDD-OpenSource/DeepADoTS
 [Base implementation for AutoEncoder, LSTM-ED](https://github.com/KDD-OpenSource/DeepADoTS)
-[Base implementation for Omni-anomaly] (https://github.com/NetManAIOps/OmniAnomaly)  
+[Base implementation for Omni-anomaly](https://github.com/NetManAIOps/OmniAnomaly)  
 [Base implementation for VAE-LSTM](https://github.com/TimyadNyda/Variational-Lstm-Autoencoder)
 [Base implementation for MSCRED 1](https://github.com/Zhang-Zhi-Jie/Pytorch-MSCRED) [Base implementation for MSCRED 2](https://github.com/SKvtun/MSCRED-Pytorch)
 [TCN module](https://github.com/locuslab/TCN)

--- a/get_datasets.sh
+++ b/get_datasets.sh
@@ -31,9 +31,11 @@ rm -r data/raw/smd
 # SKAB
 mkdir data/raw/skab && cd data/raw/skab
 curl -L https://github.com/waico/SKAB/tarball/master | tar xz --strip-components=1
+# remove docs  LICENSE  notebooks  README.md  utils
 rm -r docs
 rm -r notebooks
 rm -r utils
-rm -v !("data") && mv data/* ../skab
+rm LICENSE
+rm README.md
+mv data/* ../skab
 rm -r data/
-


### PR DESCRIPTION
    Fix bash run fail during the skab dataset download
    
    - in linux and mac, the following error is shown during the skab
      download
    - update the script to fix the issue
    
    ```
    ...
    .: syntax error near unexpected token `('
    .: `rm -v !("data") && mv data/* ../skab'
    ```