### PR TITLE
Update python version from 3.6 to 3.6.8 in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,7 +107,7 @@ Put all the datasets in the data/raw/ directory.
 
 ```bash
 git clone https://github.com/astha-chem/mvts-ano-eval.git
-conda create -n mvtsenv python=3.6
+conda create -n mvtsenv python=3.6.8
 source activate mvtsenv
 python3 -m pip3 install --user --upgrade pip
 pip install -r requirements.txt --user


### PR DESCRIPTION
If using python `3.6`, cannot solve error of `matplotlib` like following, in `pyparsing` repoI found the issue(https://github.com/pyparsing/pyparsing/issues/366) about this error. So the version of python should `>=` `3.6.8`.

![image](https://user-images.githubusercontent.com/41913261/236987199-c3d81fd7-2696-4a68-b7bd-57cc47c73f80.png)
